### PR TITLE
Pre-filter by type and ip on discovery

### DIFF
--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -16,7 +16,11 @@ import {
     IDiscoveryNetworkFactory,
     INetworkConfig,
 } from "../discovery/model";
-import { StandardDiscoveryNetworkFactory } from "../discovery/standard";
+import {
+    StandardDiscoveryNetworkFactory,
+    StandardPS4DiscoveryNetworkFactory,
+    StandardPS5DiscoveryNetworkFactory
+} from "../discovery/standard";
 import { MimCredentialRequester } from "../credentials/mim-requester";
 import { DiskCredentialsStorage } from "../credentials/disk-storage";
 import { IConnectionConfig, IDevice } from "../device/model";
@@ -229,7 +233,14 @@ export class DeviceOptions extends DiscoveryOptions {
         const args = process.argv;
         const proxiedUserId = RootProxyDevice.extractProxiedUserId(args);
 
-        const networkFactory = StandardDiscoveryNetworkFactory;
+        const deviceType = this.requestedDeviceType;
+        const networkFactory =
+          deviceType == DeviceType.PS4
+            ? StandardPS4DiscoveryNetworkFactory
+            : deviceType == DeviceType.PS5
+            ? StandardPS5DiscoveryNetworkFactory
+            : StandardDiscoveryNetworkFactory;
+
         const diskCredentialsStorage = new DiskCredentialsStorage(
             this.credentialsPath,
         );
@@ -248,7 +259,11 @@ export class DeviceOptions extends DiscoveryOptions {
             description,
             predicate,
             networkConfig,
-            this.discoveryConfig,
+            {
+                ...this.discoveryConfig,
+                deviceIp: this.deviceIp,
+                deviceType: this.requestedDeviceType
+            },
             networkFactory,
             credentials,
         );

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -43,10 +43,11 @@ export class Discovery {
             }
         });
 
-        network.ping(); // send an initial ping immediately
+        const deviceIp = this.discoveryConfig.deviceIp;
+        network.ping(deviceIp); // send an initial ping immediately
         const discoverInterval = setInterval(() => {
             debug("sending subsequent network discovery ping");
-            network.ping();
+            network.ping(deviceIp);
         }, fullConfig.pingIntervalMillis);
 
         function stopDiscovering() {

--- a/src/discovery/composite.ts
+++ b/src/discovery/composite.ts
@@ -11,7 +11,7 @@ export class CompositeDiscoveryNetwork implements IDiscoveryNetwork {
         }
     }
 
-    public async ping(deviceIp: string | undefined) {
+    public async ping(deviceIp?: string) {
         await Promise.all(this.delegates.map(d => d.ping(deviceIp)));
     }
 

--- a/src/discovery/composite.ts
+++ b/src/discovery/composite.ts
@@ -11,8 +11,8 @@ export class CompositeDiscoveryNetwork implements IDiscoveryNetwork {
         }
     }
 
-    public async ping() {
-        await Promise.all(this.delegates.map(d => d.ping()));
+    public async ping(deviceIp: string | undefined) {
+        await Promise.all(this.delegates.map(d => d.ping(deviceIp)));
     }
 
     public async send(

--- a/src/discovery/model.ts
+++ b/src/discovery/model.ts
@@ -11,6 +11,8 @@ export interface IDiscoveryConfig {
     pingIntervalMillis: number;
     timeoutMillis: number;
     uniqueDevices: boolean;
+    deviceIp?: string;
+    deviceType?: DeviceType;
 }
 
 export const defaultDiscoveryConfig: IDiscoveryConfig = {
@@ -100,7 +102,7 @@ export interface IDiscoveryNetwork {
     close(): void;
 
     /** Request devices on the network to identify themselves */
-    ping(): Promise<void>;
+    ping(deviceIp: string | undefined): Promise<void>;
 
     send(
         recipientAddress: string,

--- a/src/discovery/model.ts
+++ b/src/discovery/model.ts
@@ -101,8 +101,9 @@ export type OnDiscoveryMessageHandler = (message: IDiscoveryMessage) => void;
 export interface IDiscoveryNetwork {
     close(): void;
 
-    /** Request devices on the network to identify themselves */
-    ping(deviceIp: string | undefined): Promise<void>;
+    /** Request devices on the network to identify themselves. A specific
+      * `deviceIp` may be provided to instead talk to a specific device */
+    ping(deviceIp?: string): Promise<void>;
 
     send(
         recipientAddress: string,

--- a/src/discovery/standard.ts
+++ b/src/discovery/standard.ts
@@ -14,15 +14,19 @@ import {
 } from "./model";
 import { UdpDiscoveryNetworkFactory } from "./udp";
 
+export const StandardPS4DiscoveryNetworkFactory = new UdpDiscoveryNetworkFactory(
+    wakePortsByType[DeviceType.PS4],
+    DiscoveryVersions.PS4,
+);
+
+export const StandardPS5DiscoveryNetworkFactory = new UdpDiscoveryNetworkFactory(
+    wakePortsByType[DeviceType.PS5],
+    DiscoveryVersions.PS5,
+);
+
 const standardFactories = [
-    new UdpDiscoveryNetworkFactory(
-        wakePortsByType[DeviceType.PS4],
-        DiscoveryVersions.PS4,
-    ),
-    new UdpDiscoveryNetworkFactory(
-        wakePortsByType[DeviceType.PS5],
-        DiscoveryVersions.PS5,
-    ),
+    StandardPS4DiscoveryNetworkFactory,
+    StandardPS5DiscoveryNetworkFactory,
 ];
 
 export const StandardDiscoveryNetworkFactory: IDiscoveryNetworkFactory = {

--- a/src/discovery/udp.ts
+++ b/src/discovery/udp.ts
@@ -81,8 +81,8 @@ export class UdpDiscoveryNetwork implements IDiscoveryNetwork {
         this.socketManager.release(this.boundPort);
     }
 
-    public async ping() {
-        return this.send(BROADCAST_ADDRESS, this.port, "SRCH");
+    public async ping(deviceIp: string | undefined) {
+        return this.send(deviceIp ?? BROADCAST_ADDRESS, this.port, "SRCH");
     }
 
     public async send(

--- a/src/discovery/udp.ts
+++ b/src/discovery/udp.ts
@@ -81,7 +81,7 @@ export class UdpDiscoveryNetwork implements IDiscoveryNetwork {
         this.socketManager.release(this.boundPort);
     }
 
-    public async ping(deviceIp: string | undefined) {
+    public async ping(deviceIp?: string) {
         return this.send(deviceIp ?? BROADCAST_ADDRESS, this.port, "SRCH");
     }
 


### PR DESCRIPTION
If an IP or DeviceType is specified in the device options, use that to perform early filtering, by

  - IP: If an IP is specified, ping that IP directly instead of the UDP broadcast
  - DeviceType: Restrict the discovery network factory to only the one with the correct port

The IP one is particularly useful for networks that don't support broadcast.