### PR TITLE
Fix for network settings in "browse" command

### DIFF
--- a/src/cli/commands/browse.ts
+++ b/src/cli/commands/browse.ts
@@ -21,7 +21,7 @@ export default class extends Command {
             options.discoveryConfig,
         );
 
-        for await (const device of discovery.discover()) {
+        for await (const device of discovery.discover(options.networkConfig)) {
             options.logResult(device);
         }
     }


### PR DESCRIPTION
This change allows the options `--bind-address` and `--bind-port` to be actually passed to the Discovery object in the `browse` command.